### PR TITLE
Update appropriate <section> class in user profile section

### DIFF
--- a/plugins/talk-plugin-profile-data/client/components/DownloadCommentHistory.js
+++ b/plugins/talk-plugin-profile-data/client/components/DownloadCommentHistory.js
@@ -54,7 +54,7 @@ class DownloadCommentHistory extends Component {
     const canRequestDownload = !lastAccountDownloadDate || hoursLeft <= 0;
 
     return (
-      <section className={'talk-plugin-ignore-user-section'}>
+      <section className={'talk-plugin-profile-data--download-my-comment-history'}>
         <h3>{t('download_request.section_title')}</h3>
         <p>
           {t('download_request.you_will_get_a_copy')}{' '}


### PR DESCRIPTION
Download my comment history has `talk-plugin-ignore-user-section` class. Should be `talk-plugin-profile-data--download-my-comment-history` (couldn't figure out the proper naming convention used).

## What does this PR do?
Updates a class in the markup in the My Profile tab, to reflect the correct section name.

## How do I test this PR?

- Go to My Profile tab.
- Click on Settings tab inside My Profile.
- Inspect, via devtools, the markup wrapping Download My Comment History section.
- HTML class should not be `talk-plugin-ignore-user-section`